### PR TITLE
Solución a error en Make Submission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,5 @@ RUN pip install --upgrade pip && pip install \
     mypy \
     pylint \
     pytest \
-    pytest-cov \
-    scikit-learn \
-    tensorflow
+    pytest-cov
 RUN Rscript -e "install.packages(c('covr', 'devtools', 'DT', 'lintr', 'roxygen2', 'styler', 'testthat', 'vdiffr'), repos='http://cran.rstudio.com')"

--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ de tu modelo en GitHub Actions en la sección _Evaluate a directory_.
 - [The pull request author’s guide to getting through code review](https://google.github.io/eng-practices/review/developer/)
 - [_Forkeado_ de un repositorio](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo)
 
-----
+---


### PR DESCRIPTION
El problema de incompatibilidad entre las versiones de los módulos:
tensorflow y scikit-learn, causa error en el paso Make Submission
Se modifica el archivo Dockerfile para borrar la instalación de estos.
Además, se regresa la modificación al archivo Readme del issue #4.

## Revisión
- [ ] [Fija la versión de `mutmut` 👾](https://github.com/IslasGECI/admision_voluntariado_gmoivan/pull/8#discussion_r1925748677)